### PR TITLE
Release 2.8.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ license {
 }
 
 group = "de.chojo"
-version = "2.8.2+beta.5"
+version = "2.8.3+beta.5"
 description = "Discord utilities for use with JDA"
 
 publishData {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     api("com.fasterxml.jackson.core", "jackson-databind", "2.14.2")
 
     // web api
-    api("io.javalin", "javalin", "5.3.2")
+    api("io.javalin", "javalin", "5.4.0")
     api("io.javalin", "javalin-openapi", "4.6.7")
 
     // unit testing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     api("com.fasterxml.jackson.core", "jackson-databind", "2.14.2")
 
     // web api
-    api("io.javalin", "javalin", "5.4.0")
+    api("io.javalin", "javalin", "4.6.7")
     api("io.javalin", "javalin-openapi", "4.6.7")
 
     // unit testing

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
go back to javalin 4.x

Javalin 5.x currently does not have a way to define openapi documentation on runtime, which is required by cjda and some of its depending projects