### PR TITLE
Fix name of Message and User commands not localized

### DIFF
--- a/src/main/java/de/chojo/jdautil/interactions/message/Message.java
+++ b/src/main/java/de/chojo/jdautil/interactions/message/Message.java
@@ -28,7 +28,7 @@ public class Message implements Interaction, MessageHandler, CommandDataProvider
         this.handler = handler;
     }
 
-    public static PartialMessageBuilder of(String name){
+    public static PartialMessageBuilder of(String name) {
         return MessageBuilder.of(name);
     }
 
@@ -45,11 +45,12 @@ public class Message implements Interaction, MessageHandler, CommandDataProvider
     @Override
     public CommandData toCommandData(ILocalizer localizer) {
         var message = Commands.message(meta.name())
-                              .setGuildOnly(meta.isGuildOnly())
-                              .setDefaultPermissions(meta.permission())
-                              .setDefaultPermissions(meta.permission());
+                .setGuildOnly(meta.isGuildOnly())
+                .setDefaultPermissions(meta.permission())
+                .setDefaultPermissions(meta.permission());
         if (meta.localized()) {
-            message.setNameLocalizations(localizer.prefixedLocalizer("message").apply(localeKey()));
+            message.setNameLocalizations(localizer.prefixedLocalizer("message").apply(localeKey()))
+                    .setLocalizationFunction(localizer.prefixedLocalizer("message"));
         }
         return message;
     }

--- a/src/main/java/de/chojo/jdautil/interactions/user/User.java
+++ b/src/main/java/de/chojo/jdautil/interactions/user/User.java
@@ -45,10 +45,11 @@ public class User implements Interaction, UserHandler, CommandDataProvider {
     @Override
     public CommandData toCommandData(ILocalizer localizer) {
         var user = Commands.user(meta.name())
-                           .setGuildOnly(meta.isGuildOnly())
-                           .setDefaultPermissions(meta.permission());
+                .setGuildOnly(meta.isGuildOnly())
+                .setDefaultPermissions(meta.permission());
         if (meta.localized()) {
-            user.setNameLocalizations(localizer.prefixedLocalizer("user").apply(localeKey()));
+            user.setNameLocalizations(localizer.prefixedLocalizer("user").apply(localeKey()))
+                    .setLocalizationFunction(localizer.prefixedLocalizer("user"));
         }
         return user;
     }


### PR DESCRIPTION
Improved localization in the Message and User classes by adding the 'setLocalizationFunction' method for accurate localization. Additionally, adjusted the formatting of the 'of' method within the Message class.